### PR TITLE
Enable rendering pages registered by plugins

### DIFF
--- a/netbox_tunnels2/templates/netbox_tunnels2/tunnel.html
+++ b/netbox_tunnels2/templates/netbox_tunnels2/tunnel.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% block content %}
   <div class="row mb-3">
     <div class="col col-md-6">
@@ -34,10 +35,12 @@
         </div>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}
+      {% plugin_right_page object %}
     </div>
   </div>
   <div class="row">
@@ -78,11 +81,16 @@
       </div>
     </div>
   </div>
-  <div class="row">
+  <div class="row mb-3">
     <div class="col col-md-6">
 
     
 
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col col-md-12">
+      {% plugin_full_width_page object %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox_tunnels2/templates/netbox_tunnels2/tunneltype.html
+++ b/netbox_tunnels2/templates/netbox_tunnels2/tunneltype.html
@@ -1,4 +1,5 @@
 {% extends 'generic/object.html' %}
+{% load plugins %}
 {% load render_table from django_tables2 %}
 {% block content %}
   <div class="row mb-3">
@@ -15,11 +16,13 @@
         </div>
       </div>
       {% include 'inc/panels/custom_fields.html' %}
+      {% plugin_left_page object %}
     </div>
     <div class="col col-md-6">
+      {% plugin_right_page object %}
     </div>
   </div>
-  <div class="row">
+  <div class="row mb-3">
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Tunnels</h5>
@@ -27,6 +30,11 @@
           {% render_table tunnel_table %}
         </div>
       </div>
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col col-md-12">
+      {% plugin_full_width_page object %}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
- Add blocks for rendering extra content by registered plugins.
- Inspired by official object detail templates like https://github.com/netbox-community/netbox/blob/70c2b358ad6c778344b2ee0639dab6b76f751fdc/netbox/templates/ipam/asn.html#L55 
- Enables render extra content by plugins like https://github.com/Kani999/netbox-attachments 
   -  https://github.com/Kani999/netbox-attachments/issues/31