### PR TITLE
Fix title & align custom fields in template

### DIFF
--- a/netbox_tunnels2/templates/netbox_tunnels2/tunnel_edit.html
+++ b/netbox_tunnels2/templates/netbox_tunnels2/tunnel_edit.html
@@ -2,8 +2,6 @@
 {% load static %}
 {% load form_helpers %}
 
-{% block title %}{% if obj.pk %}Editing {{ obj }}{% else %}Add a tunnel{% endif %}{% endblock %}
-
 {% block form %}
 {% render_errors form %}
 <div class="field-group">
@@ -37,17 +35,15 @@
     </div>
 </div>
 
+{% if form.custom_fields %}
+    <div class="field-group">
+        <h4>Custom Fields</h4>
+            {% render_custom_fields form %}
+    </div>
+{% endif %}
 
 <div class="field-group">
     <h4>Comments</h4>
     {% render_field form.comments %}
 </div>
-{% if form.custom_fields %}
-    <div class="card">
-        <h5 class="card-header">Custom Fields</h5>
-        <div class="card-body">
-            {% render_custom_fields form %}
-        </div>
-    </div>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
The dynamic title (whether a tunnel was being edited or a new one created) wasnt working, and from my test, the title block is not needed at all for this to work. So I simply removed it and the title now dynamically changes.

I also changed the custom fields to look like the other fields. Before, they were looking very differently and had a strange background.

I also moved the custom fields directly above the comment field, just as they are elsewhere in Netbox.
Comments are generally always at the bottom.