### PR TITLE
Add related tunnels to side A interfaces

### DIFF
--- a/netbox_tunnels2/tables.py
+++ b/netbox_tunnels2/tables.py
@@ -31,26 +31,17 @@ COL_SIDE_B_HOST_ASSIGNMENT = """
     {% endif %}
  """
 
-class TunnelTable(NetBoxTable):
-    """Table for displaying configured Tunnel instances."""
+
+class RelatedTunnelTable(NetBoxTable):
+    """Table for displaying Tunnel instances related to an interface."""
     name = tables.Column(
         linkify=True
     )
     tunnel_type = tables.Column(linkify=True)
-    a_pub_address = tables.Column(linkify=True)
     b_pub_address = tables.Column(linkify=True)
     status = ChoiceFieldColumn()
     tenant = tables.Column(linkify=True)
 
-    side_a_host = tables.TemplateColumn(
-        template_code=COL_SIDE_A_HOST_ASSIGNMENT,
-        verbose_name="Side A Host",
-    )
-    side_a_assigned_object = tables.Column(
-        linkify=True,
-        orderable=False,
-        verbose_name="Side A Interface",
-    )
     side_b_host = tables.TemplateColumn(
         template_code=COL_SIDE_B_HOST_ASSIGNMENT,
         verbose_name="Side B Host",
@@ -60,8 +51,10 @@ class TunnelTable(NetBoxTable):
         orderable=False,
         verbose_name="Side B Interface",
     )
+
     class Meta(NetBoxTable.Meta):
-        """Class to define what is used for tunnel_lists.html template to show configured tunnels."""
+        """Class to define what is used for interface_extend.html template to show
+        tunnels related to an interface"""
 
         model = Tunnel
         fields = (
@@ -70,15 +63,38 @@ class TunnelTable(NetBoxTable):
             "name",
             "tenant",
             "tunnel_type",
-            "side_a_host",
-            "side_a_assigned_object",
             "side_b_host",
             "side_b_assigned_object",
             "status",
-            "a_pub_address",
             "b_pub_address"
         )
-        default_columns = ('name', 'status', 'tunnel_type', 'side_a_host', 'side_b_host','a_pub_address', 'b_pub_address')
+        default_columns = ('name', 'status', 'tunnel_type',
+                           'side_b_host', 'b_pub_address')
+
+
+class TunnelTable(RelatedTunnelTable):
+    """Table for displaying configured Tunnel instances."""
+    a_pub_address = tables.Column(linkify=True)
+    side_a_host = tables.TemplateColumn(
+        template_code=COL_SIDE_A_HOST_ASSIGNMENT,
+        verbose_name="Side A Host",
+    )
+    side_a_assigned_object = tables.Column(
+        linkify=True,
+        orderable=False,
+        verbose_name="Side A Interface",
+    )
+
+    class Meta(RelatedTunnelTable.Meta):
+        """Class to define what is used for tunnel_lists.html template to show configured tunnels."""
+
+        RelatedTunnelTable.Meta.fields += (
+            "side_a_host",
+            "side_a_assigned_object",
+            "a_pub_address",
+        )
+        RelatedTunnelTable.Meta.default_columns += ('side_a_host', 'a_pub_address')
+
 
 class TunnelTypeTable(NetBoxTable):
     """Table for displaying configured Tunnel instances."""

--- a/netbox_tunnels2/template_content.py
+++ b/netbox_tunnels2/template_content.py
@@ -1,0 +1,26 @@
+from extras.plugins import PluginTemplateExtension
+from .models import Tunnel
+from .tables import RelatedTunnelTable
+from django.contrib.contenttypes.models import ContentType
+
+
+class InterfaceTunnels(PluginTemplateExtension):
+    model = 'dcim.interface'
+
+    def full_width_page(self):
+        obj = self.context.get('object')
+        types = ContentType.objects.get_for_model(obj)
+        tunnel = Tunnel.objects.filter(
+            side_a_assigned_object_type=types,
+            side_a_assigned_object_id=obj.id,
+        )
+        tunnel_table = RelatedTunnelTable(tunnel)
+        return self.render(
+            'netbox_tunnels2/interface_extend.html',
+            extra_context={
+                'related_tunnels': tunnel_table
+            }
+        )
+
+
+template_extensions = [InterfaceTunnels]

--- a/netbox_tunnels2/templates/netbox_tunnels2/interface_extend.html
+++ b/netbox_tunnels2/templates/netbox_tunnels2/interface_extend.html
@@ -1,5 +1,3 @@
-{% load helpers %}
-
 {% if related_tunnels %}
 {% load render_table from django_tables2 %}
 <div class="card">
@@ -8,6 +6,11 @@
     </h5>
     <div class="card-body">
         {% render_table related_tunnels 'inc/table.html' %}
+    </div>
+    <div class="card-footer text-end noprint">
+        <a href="{% url 'plugins:netbox_tunnels2:tunnel_add' %}?side_a_interface={{ object.pk }}&return_url={% url 'dcim:interface' pk=object.pk %}" class="btn btn-primary btn-sm">
+          <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a VPN Tunnel
+        </a>
     </div>
 </div>
 {% endif %}

--- a/netbox_tunnels2/templates/netbox_tunnels2/interface_extend.html
+++ b/netbox_tunnels2/templates/netbox_tunnels2/interface_extend.html
@@ -1,0 +1,13 @@
+{% load helpers %}
+
+{% if related_tunnels %}
+{% load render_table from django_tables2 %}
+<div class="card">
+    <h5 class="card-header">
+        Related VPN Tunnels
+    </h5>
+    <div class="card-body">
+        {% render_table related_tunnels 'inc/table.html' %}
+    </div>
+</div>
+{% endif %}


### PR DESCRIPTION
This PR adds related tunnels to the view of side A interfaces.

Example:
![image](https://github.com/robertlynch3/netbox-tunnels2/assets/13933258/f31aebdc-3c77-494e-9851-818ca07bf340)

Im not 100% sure if the changes I made to tables.py is the best solution or if reversing the class extension and overriding the Meta "fields" and "default_columns" would be better.

I went with the current approach for now as it was a natural extension.

PS:
I want to look at two further things later. Issue #11 and validating whether the IPs belong to the interfaces linked.